### PR TITLE
Extension for multi-container local host and port (to pod)

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -28,13 +28,21 @@ if [ -n "${ENABLE_BASIC_AUTH+1}" ] && [ "${ENABLE_BASIC_AUTH,,}" = "true" ]; the
 fi
 
 # If the SERVICE_HOST_ENV_NAME and SERVICE_PORT_ENV_NAME vars are provided,
+# there are two options:
+#  - Option 1:
 # they point to the env vars set by Kubernetes that contain the actual
 # target address and port. Override the default with them.
+#  - Option 2:
+# they point to a host and port accessible from the container, respectively,
+# as in a multi-container pod scenario in Kubernetes.
+# E.g.
+#    - SERVICE_HOST_ENV_NAME=localhost
+#    - SERVICE_PORT_ENV_NAME=8080
 if [ -n "${SERVICE_HOST_ENV_NAME+1}" ]; then
-  TARGET_SERVICE=${!SERVICE_HOST_ENV_NAME}
+  TARGET_SERVICE=${!SERVICE_HOST_ENV_NAME:=$SERVICE_HOST_ENV_NAME}
 fi
 if [ -n "${SERVICE_PORT_ENV_NAME+1}" ]; then
-  TARGET_SERVICE="$TARGET_SERVICE:${!SERVICE_PORT_ENV_NAME}"
+  TARGET_SERVICE="$TARGET_SERVICE:${!SERVICE_PORT_ENV_NAME:=$SERVICE_PORT_ENV_NAME}"
 fi
 
 # Tell nginx the address and port of the service to proxy to

--- a/start.sh
+++ b/start.sh
@@ -39,9 +39,13 @@ fi
 #    - SERVICE_HOST_ENV_NAME=localhost
 #    - SERVICE_PORT_ENV_NAME=8080
 if [ -n "${SERVICE_HOST_ENV_NAME+1}" ]; then
+  # get value of the env variable in SERVICE_HOST_ENV_NAME as host, if that's not set,
+  # SERVICE_HOST_ENV_NAME has the host value
   TARGET_SERVICE=${!SERVICE_HOST_ENV_NAME:=$SERVICE_HOST_ENV_NAME}
 fi
 if [ -n "${SERVICE_PORT_ENV_NAME+1}" ]; then
+  # get value of the env variable in SERVICE_PORT_ENV_NAME as port, if that's not set,
+  # SERVICE_PORT_ENV_NAME has the port value
   TARGET_SERVICE="$TARGET_SERVICE:${!SERVICE_PORT_ENV_NAME:=$SERVICE_PORT_ENV_NAME}"
 fi
 


### PR DESCRIPTION
This is the scenario we ran into when trying to secure cross service communications at the pod level and allowing no non-secure communications to that specific service. This change allows proxying from the Nginx SSL container to another container in the same pod, e.g. localhost:8080.

The `spec` section in the `ReplicationController` config would look something like this:

```
spec:
  containers:
    - name: "app"
      image: {{ app_image }}
      ports:
        - name: pod-http
          containerPort: 8080
          protocol: "TCP"
    - name: "nginx-ssl-proxy"
      image: {{ ssl_proxy_image }}
      env:
        - name: SERVICE_HOST_ENV_NAME
          value: localhost
        - name: SERVICE_PORT_ENV_NAME
          value: "8080"
        - name: ENABLE_SSL
          value: 'true'
      ports:
        - name: pod-https
          containerPort: 443
          protocol: "TCP"
      volumeMounts:
        - name: secrets
          mountPath: /etc/secrets
          readOnly: true
  volumes:
    - name: secrets
      secret:
        secretName: ssl-proxy-secret
```

Then, there is a Kubernetes `Service` layer forwarding requests to port 443 to the port named `pod-https` for secure communications!
