### PR TITLE
Provide optional ability to proxy through to a certservice

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,11 @@ WORKDIR /usr/src
 ADD start.sh /usr/src/
 ADD nginx/nginx.conf /etc/nginx/
 ADD nginx/proxy*.conf /usr/src/
+ADD nginx/default*.conf /usr/src/
 
 RUN mkdir /etc/nginx/snippets/
 RUN mkdir -p /tmp/letsencrypt/.well-known/acme-challenge/
 RUN echo "OK" > /tmp/letsencrypt/.well-known/acme-challenge/health
 ADD nginx/letsencrypt.conf /etc/nginx/snippets/letsencrypt.conf
 
-ENTRYPOINT ./start.sh
+CMD ["./start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,9 @@ ADD start.sh /usr/src/
 ADD nginx/nginx.conf /etc/nginx/
 ADD nginx/proxy*.conf /usr/src/
 
+RUN mkdir /etc/nginx/snippets/
+RUN mkdir -p /tmp/letsencrypt/.well-known/acme-challenge/
+RUN echo "OK" > /tmp/letsencrypt/.well-known/acme-challenge/health
+ADD nginx/letsencrypt.conf /etc/nginx/snippets/letsencrypt.conf
+
 ENTRYPOINT ./start.sh

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ Here's how the replication controller and service would function terminating SSL
 
 See [https://github.com/GoogleCloudPlatform/kube-jenkins-imager](https://github.com/GoogleCloudPlatform/kube-jenkins-imager) for a complete tutorial that uses the `nginx-ssl-proxy` in Kubernetes.
 
+## Generating test certificates
+
+Use the setup-certs.sh script to generate test certificates. It will create your own Certificate Authority and
+use that to self sign a certificate.
+
+    ./setup-certs.sh /path/to/certs/folder
+
+**THIS IS NOT FOR PRODUCTION USE.**
+
 ## Run an SSL Termination Proxy from the CLI
 To run an SSL termination proxy you must have an existing SSL certificate and key. These instructions assume they are stored at /path/to/secrets/ and named `cert.crt` and `key.pem`. You'll need to change those values based on your actual file path and names.
 
@@ -41,7 +50,7 @@ To run an SSL termination proxy you must have an existing SSL certificate and ke
       -v /path/to/secrets/dhparam.pem:/etc/secrets/dhparam \
       nginx-ssl-proxy
     ```
-    The really important thing here is that you map in your cert to `/etc/secrets/proxycert`, your key to `/etc/secrets/proxykey`, and your dhparam to `/etc/secrets/dhparam` as shown in the command above. 
+    The really important thing here is that you map in your cert to `/etc/secrets/proxycert`, your key to `/etc/secrets/proxykey`, and your dhparam to `/etc/secrets/dhparam` as shown in the command above.
 
 3. **Enable Basic Access Authentication**
 

--- a/README.md
+++ b/README.md
@@ -74,3 +74,9 @@ To run an SSL termination proxy you must have an existing SSL certificate and ke
  destination should be defined using the CERT_SERVICE env variable.
 
  The CERT_SERVICE will receive all requests to `/.well-known/acme-challenge`
+
+ ## Other env vars:
+
+  - **SERVER_NAME**
+    If set, this must be provided and will be set as the value in the
+    `server_name` directive.

--- a/README.md
+++ b/README.md
@@ -11,12 +11,6 @@ docker build -t nginx-ssl-proxy .
 ## Using with Kubernetes
 This image is optimized for use in a Kubernetes cluster to provide SSL termination for other services in the cluster. It should be deployed as a [Kubernetes replication controller](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/replication-controller.md) with a [service and public load balancer](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/services.md) in front of it. SSL certificates, keys, and other secrets are managed via the [Kubernetes Secrets API](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/design/secrets.md).
 
-Here's how the replication controller and service would function terminating SSL for Jenkins in a Kubernetes cluster:
-
-![](img/architecture.png)
-
-See [https://github.com/GoogleCloudPlatform/kube-jenkins-imager](https://github.com/GoogleCloudPlatform/kube-jenkins-imager) for a complete tutorial that uses the `nginx-ssl-proxy` in Kubernetes.
-
 ## Generating test certificates
 
 Use the setup-certs.sh script to generate test certificates. It will create your own Certificate Authority and
@@ -73,3 +67,10 @@ To run an SSL termination proxy you must have an existing SSL certificate and ke
       -v /path/to/secrets/htpasswd:/etc/secrets/htpasswd \
       nginx-ssl-proxy
     ```
+
+ ## Connecting to a certification service
+
+ The nginx file supports proxying `/.well-known/acme-challenge` requests. The
+ destination should be defined using the CERT_SERVICE env variable.
+
+ The CERT_SERVICE will receive all requests to `/.well-known/acme-challenge`

--- a/nginx/default_nossl.conf
+++ b/nginx/default_nossl.conf
@@ -1,0 +1,5 @@
+server {
+    listen       80 default_server;
+    server_name  _;
+    return       444;
+}

--- a/nginx/default_ssl.conf
+++ b/nginx/default_ssl.conf
@@ -1,12 +1,15 @@
+server {
+     listen 80 default;
+     return 444;
+}
 
 server {
-    listen       80;
-    listen       443 default_server ssl;
-    server_name  _;
+    listen 443 default;
 
     ssl_certificate /etc/secrets/proxycert;
     ssl_certificate_key /etc/secrets/proxykey;
     ssl_dhparam /etc/secrets/dhparam;
 
-    return       444;
+    ssl on;
+    return 444;
 }

--- a/nginx/default_ssl.conf
+++ b/nginx/default_ssl.conf
@@ -1,0 +1,12 @@
+
+server {
+    listen       80;
+    listen       443 default_server ssl;
+    server_name  _;
+
+    ssl_certificate /etc/secrets/proxycert;
+    ssl_certificate_key /etc/secrets/proxykey;
+    ssl_dhparam /etc/secrets/dhparam;
+
+    return       444;
+}

--- a/nginx/letsencrypt.conf
+++ b/nginx/letsencrypt.conf
@@ -1,0 +1,3 @@
+location /.well-known/acme-challenge {
+   alias /tmp/letsencrypt/.well-known/acme-challenge;
+}

--- a/nginx/letsencrypt.conf
+++ b/nginx/letsencrypt.conf
@@ -1,3 +1,8 @@
 location /.well-known/acme-challenge {
-   alias /tmp/letsencrypt/.well-known/acme-challenge;
+    proxy_set_header        Host $host;
+    proxy_set_header        X-Real-IP $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header        X-Forwarded-Proto $scheme;
+    proxy_pass              http://cert_service;
+    proxy_read_timeout      90;
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -27,5 +27,5 @@ http {
 
     #gzip  on;
     client_max_body_size 20M;
-    include /etc/nginx/conf.d/proxy.conf;
+    include /etc/nginx/conf.d/*;
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -27,5 +27,7 @@ http {
 
     #gzip  on;
     client_max_body_size 20M;
-    include /etc/nginx/conf.d/*;
+    include /etc/nginx/conf.d/proxy.conf;
+    include /etc/nginx/conf.d/default.conf;
+
 }

--- a/nginx/proxy_nossl.conf
+++ b/nginx/proxy_nossl.conf
@@ -3,7 +3,7 @@ upstream target_service {
 }
 
 server {
-  server_name _;
+  server_name {{SERVER_NAME}};
   listen 80;
 
   location / {
@@ -11,8 +11,8 @@ server {
     proxy_set_header        X-Real-IP $remote_addr;
     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header        X-Forwarded-Proto $scheme;
-    proxy_pass http://target_service;
-    proxy_read_timeout  90;
+    proxy_pass              http://target_service;
+    proxy_read_timeout      90;
     #auth_basic              "Restricted";
     #auth_basic_user_file    /etc/secrets/htpasswd;
   }

--- a/nginx/proxy_nossl.conf
+++ b/nginx/proxy_nossl.conf
@@ -5,7 +5,7 @@ upstream target_service {
 server {
   server_name _;
   listen 80;
-  
+
   location / {
     proxy_set_header        Host $host;
     proxy_set_header        X-Real-IP $remote_addr;
@@ -14,6 +14,6 @@ server {
     proxy_pass http://target_service;
     proxy_read_timeout  90;
     #auth_basic              "Restricted";
-    #auth_basic_user_file    /etc/secrets/htpasswd; 
+    #auth_basic_user_file    /etc/secrets/htpasswd;
   }
 }

--- a/nginx/proxy_ssl.conf
+++ b/nginx/proxy_ssl.conf
@@ -2,9 +2,9 @@ upstream target_service {
   server {{TARGET_SERVICE}};
 }
 
-upstream cert_service {
-  server {{CERT_SERVICE}};
-}
+#letsencrypt# upstream cert_service {
+#letsencrypt#   server {{CERT_SERVICE}};
+#letsencrypt# }
 
 
 server {
@@ -15,7 +15,7 @@ server {
     return 301 https://$host$request_uri;
   }
 
-  include /etc/nginx/snippets/letsencrypt.conf;
+  #letsencrypt# include /etc/nginx/snippets/letsencrypt.conf;
 
 }
 

--- a/nginx/proxy_ssl.conf
+++ b/nginx/proxy_ssl.conf
@@ -8,7 +8,7 @@ upstream target_service {
 
 
 server {
-  server_name _;
+  server_name {{SERVER_NAME}};
   listen 80;
 
   location / {
@@ -20,7 +20,7 @@ server {
 }
 
 server {
-  server_name _;
+  server_name {{SERVER_NAME}};
   listen 443;
 
   ssl on;

--- a/nginx/proxy_ssl.conf
+++ b/nginx/proxy_ssl.conf
@@ -2,6 +2,11 @@ upstream target_service {
   server {{TARGET_SERVICE}};
 }
 
+upstream cert_service {
+  server {{CERT_SERVICE}};
+}
+
+
 server {
   server_name _;
   listen 80;

--- a/nginx/proxy_ssl.conf
+++ b/nginx/proxy_ssl.conf
@@ -5,11 +5,17 @@ upstream target_service {
 server {
   server_name _;
   listen 80;
-  return 301 https://$host$request_uri;
+
+  location / {
+    return 301 https://$host$request_uri;
+  }
+
+  include /etc/nginx/snippets/letsencrypt.conf;
+
 }
 
 server {
-  server_name _; 
+  server_name _;
   listen 443;
 
   ssl on;
@@ -20,20 +26,20 @@ server {
   ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
   ssl_ciphers ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-RSA-RC4-SHA:AES128-GCM-SHA256:HIGH:!RC4:!MD5:!aNULL:!EDH:!CAMELLIA;
   ssl_prefer_server_ciphers on;
-  
+
   ssl_session_cache shared:SSL:10m;
   ssl_session_timeout 10m;
- 
+
   ssl_session_tickets off;
   ssl_stapling on;
   ssl_stapling_verify on;
   resolver 8.8.8.8 8.8.4.4 valid=300s;
   resolver_timeout 5s;
- 
+
   add_header Strict-Transport-Security max-age=15638400;
   add_header X-Frame-Options DENY;
   add_header X-Content-Type-Options nosniff;
- 
+
   location / {
       proxy_set_header        Host $host;
       proxy_set_header        X-Real-IP $remote_addr;
@@ -44,7 +50,6 @@ server {
       proxy_read_timeout      90;
       proxy_redirect          http:// https://;
       #auth_basic              "Restricted";
-      #auth_basic_user_file    /etc/secrets/htpasswd; 
+      #auth_basic_user_file    /etc/secrets/htpasswd;
   }
 }
-

--- a/nginx/proxy_ssl.conf
+++ b/nginx/proxy_ssl.conf
@@ -35,7 +35,6 @@ server {
   ssl_session_cache shared:SSL:10m;
   ssl_session_timeout 10m;
 
-  ssl_session_tickets off;
   ssl_stapling on;
   ssl_stapling_verify on;
   resolver 8.8.8.8 8.8.4.4 valid=300s;

--- a/setup-certs.sh
+++ b/setup-certs.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+LOCATION=${1:-'/tmp'}
+
+# Files required by nginx proxy
+SERVER_CERT="${LOCATION}/proxycert"
+SERVER_KEY="${LOCATION}/proxykey"
+DHPARAM="${LOCATION}/dhparam"
+
+# Files used in generating the required files.
+CA_KEY="${LOCATION}/ca.key"
+CA_CRT="${LOCATION}/ca.crt"
+SERVER_CSR="${LOCATION}/server.csr"
+
+echo $SERVER_KEY, $SERVER_CERT, $DHPARAM, $CA_KEY
+
+printf "# Create new dhparam. This may take a few minutes...\n"
+# openssl dhparam -out $DHPARAM 2048
+
+printf "\n# Create the CA...\n"
+# Create the CA Key and Certificate for signing Client Certs
+# Just enter 'pass' for the passphrase.
+# All other details can be left blank.
+openssl genrsa -des3 -out $CA_KEY 4096
+openssl req -new -x509 -days 365 -key $CA_KEY -out $CA_CRT
+
+printf "\n# Create the Server Key...\n"
+# Create the Server Key, CSR, and Certificate
+# I don't want a passphrase here.
+# All fields can be left blank
+openssl genrsa -out $SERVER_KEY 4096
+
+printf "\n# Create the Server CSR...\n"
+openssl req -new -key $SERVER_KEY -out $SERVER_CSR
+
+printf "\n# Self-sign the Server CSR...\n"
+# We're self signing our own server cert here. This is a no-no in production.
+# Just need to enter same passphrase used in creating the CA.
+openssl x509 -req -days 365 -in $SERVER_CSR -CA $CA_CRT -CAkey $CA_KEY -set_serial 01 -out $SERVER_CERT

--- a/setup-certs.sh
+++ b/setup-certs.sh
@@ -15,7 +15,7 @@ SERVER_CSR="${LOCATION}/server.csr"
 echo $SERVER_KEY, $SERVER_CERT, $DHPARAM, $CA_KEY
 
 printf "# Create new dhparam. This may take a few minutes...\n"
-# openssl dhparam -out $DHPARAM 2048
+openssl dhparam -out $DHPARAM 2048
 
 printf "\n# Create the CA...\n"
 # Create the CA Key and Certificate for signing Client Certs

--- a/setup-certs.sh
+++ b/setup-certs.sh
@@ -15,7 +15,7 @@ SERVER_CSR="${LOCATION}/server.csr"
 echo $SERVER_KEY, $SERVER_CERT, $DHPARAM, $CA_KEY
 
 printf "# Create new dhparam. This may take a few minutes...\n"
-openssl dhparam -out $DHPARAM 2048
+openssl dhparam -out $DHPARAM 128
 
 printf "\n# Create the CA...\n"
 # Create the CA Key and Certificate for signing Client Certs

--- a/start.sh
+++ b/start.sh
@@ -54,5 +54,4 @@ sed -i "s/{{TARGET_SERVICE}}/${TARGET_SERVICE}/g;" /etc/nginx/conf.d/proxy.conf
 sed -i "s/{{CERT_SERVICE}}/${CERT_SERVICE}/g;" /etc/nginx/conf.d/proxy.conf
 
 echo "Starting nginx..."
-cat /etc/nginx/conf.d/proxy.conf
 nginx -g 'daemon off;'

--- a/start.sh
+++ b/start.sh
@@ -48,10 +48,13 @@ if [ -n "${CERT_SERVICE_PORT_ENV_NAME+1}" ]; then
   CERT_SERVICE="$CERT_SERVICE:${!CERT_SERVICE_PORT_ENV_NAME}"
 fi
 
+if [ -n "${CERT_SERVICE+1}" ]; then
+    # Tell nginx the address and port of the certification service.
+    sed -i "s/{{CERT_SERVICE}}/${CERT_SERVICE}/g;" /etc/nginx/conf.d/proxy.conf
+    sed -i "s/#letsencrypt# //g;" /etc/nginx/conf.d/proxy.conf
+fi
 # Tell nginx the address and port of the service to proxy to
 sed -i "s/{{TARGET_SERVICE}}/${TARGET_SERVICE}/g;" /etc/nginx/conf.d/proxy.conf
-# Tell nginx the address and port of the certification service.
-sed -i "s/{{CERT_SERVICE}}/${CERT_SERVICE}/g;" /etc/nginx/conf.d/proxy.conf
 
 echo "Starting nginx..."
 nginx -g 'daemon off;'

--- a/start.sh
+++ b/start.sh
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 
-# Env says we're using SSL 
+# Env says we're using SSL
 if [ -n "${ENABLE_SSL+1}" ] && [ "${ENABLE_SSL,,}" = "true" ]; then
   echo "Enabling SSL..."
   cp /usr/src/proxy_ssl.conf /etc/nginx/conf.d/proxy.conf
@@ -21,7 +21,7 @@ else
   cp /usr/src/proxy_nossl.conf /etc/nginx/conf.d/proxy.conf
 fi
 
-# If an htpasswd file is provided, download and configure nginx 
+# If an htpasswd file is provided, download and configure nginx
 if [ -n "${ENABLE_BASIC_AUTH+1}" ] && [ "${ENABLE_BASIC_AUTH,,}" = "true" ]; then
   echo "Enabling basic auth..."
    sed -i "s/#auth_basic/auth_basic/g;" /etc/nginx/conf.d/proxy.conf
@@ -37,8 +37,22 @@ if [ -n "${SERVICE_PORT_ENV_NAME+1}" ]; then
   TARGET_SERVICE="$TARGET_SERVICE:${!SERVICE_PORT_ENV_NAME}"
 fi
 
+# If the CERT_SERVICE_HOST_ENV_NAME and CERT_SERVICE_PORT_ENV_NAME vars
+# are provided, they point to the env vars set by Kubernetes that contain the
+# actual target address and port of the encryption service. Override the
+# default with them.
+if [ -n "${CERT_SERVICE_HOST_ENV_NAME+1}" ]; then
+  CERT_SERVICE=${!CERT_SERVICE_HOST_ENV_NAME}
+fi
+if [ -n "${CERT_SERVICE_PORT_ENV_NAME+1}" ]; then
+  CERT_SERVICE="$CERT_SERVICE:${!CERT_SERVICE_PORT_ENV_NAME}"
+fi
+
 # Tell nginx the address and port of the service to proxy to
 sed -i "s/{{TARGET_SERVICE}}/${TARGET_SERVICE}/g;" /etc/nginx/conf.d/proxy.conf
+# Tell nginx the address and port of the certification service.
+sed -i "s/{{CERT_SERVICE}}/${CERT_SERVICE}/g;" /etc/nginx/conf.d/proxy.conf
 
 echo "Starting nginx..."
+cat /etc/nginx/conf.d/proxy.conf
 nginx -g 'daemon off;'

--- a/start.sh
+++ b/start.sh
@@ -16,9 +16,11 @@
 if [ -n "${ENABLE_SSL+1}" ] && [ "${ENABLE_SSL,,}" = "true" ]; then
   echo "Enabling SSL..."
   cp /usr/src/proxy_ssl.conf /etc/nginx/conf.d/proxy.conf
+  cp /usr/src/default_ssl.conf /etc/nginx/conf.d/default.conf
 else
   # No SSL
   cp /usr/src/proxy_nossl.conf /etc/nginx/conf.d/proxy.conf
+  cp /usr/src/default_nossl.conf /etc/nginx/conf.d/default.conf
 fi
 
 # If an htpasswd file is provided, download and configure nginx
@@ -54,7 +56,11 @@ if [ -n "${CERT_SERVICE+1}" ]; then
     sed -i "s/#letsencrypt# //g;" /etc/nginx/conf.d/proxy.conf
 fi
 # Tell nginx the address and port of the service to proxy to
-sed -i "s/{{TARGET_SERVICE}}/${TARGET_SERVICE}/g;" /etc/nginx/conf.d/proxy.conf
+sed -i "s|{{TARGET_SERVICE}}|${TARGET_SERVICE}|" /etc/nginx/conf.d/proxy.conf
+
+# Tell nginx the name of the service
+sed -i "s/{{SERVER_NAME}}/${SERVER_NAME}/g;" /etc/nginx/conf.d/proxy.conf
+
 
 echo "Starting nginx..."
 nginx -g 'daemon off;'


### PR DESCRIPTION
This is the container used in [this blog post](http://blog.ployst.com/development/2015/12/22/letsencrypt-on-kubernetes.html).

Not sure if I should add more documentation. Perhaps adding links to the blog post above and [your one](http://blog.kubernetes.io/2015/07/strong-simple-ssl-for-kubernetes.html) would make sense.

I removed stuff that wasn't specific to this container from the readme in my repo. If you'd rather I put it back for the upstream merge let me know.
