### PR TITLE
Websocket support for nginx SSL proxy

### DIFF
--- a/nginx/proxy_nossl.conf
+++ b/nginx/proxy_nossl.conf
@@ -15,5 +15,9 @@ server {
     proxy_read_timeout  90;
     #auth_basic              "Restricted";
     #auth_basic_user_file    /etc/secrets/htpasswd; 
+    # WebSocket support (nginx 1.4)
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
   }
 }

--- a/nginx/proxy_ssl.conf
+++ b/nginx/proxy_ssl.conf
@@ -45,6 +45,10 @@ server {
       proxy_redirect          http:// https://;
       #auth_basic              "Restricted";
       #auth_basic_user_file    /etc/secrets/htpasswd; 
+      # WebSocket support (nginx 1.4)
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
   }
 }
 


### PR DESCRIPTION
Hi! I am working with websockets and the standard configuration did not allow ws and wss connections. This should fix that. Let me know what you think.
