### PR TITLE
Add x-forwareded-port option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To run an SSL termination proxy you must have an existing SSL certificate and ke
       -v /path/to/secrets/dhparam.pem:/etc/secrets/dhparam \
       nginx-ssl-proxy
     ```
-    The really important thing here is that you map in your cert to `/etc/secrets/proxycert`, your key to `/etc/secrets/proxykey`, and your dhparam to `/etc/secrets/dhparam` as shown in the command above. 
+    The really important thing here is that you map in your cert to `/etc/secrets/proxycert`, your key to `/etc/secrets/proxykey`, and your dhparam to `/etc/secrets/dhparam` as shown in the command above.
 
 3. **Enable Basic Access Authentication**
 
@@ -58,6 +58,7 @@ To run an SSL termination proxy you must have an existing SSL certificate and ke
       -e ENABLE_SSL=true \
       -e ENABLE_BASIC_AUTH=true \
       -e TARGET_SERVICE=THE_ADDRESS_OR_HOST_YOU_ARE_PROXYING_TO \
+      -e X_FORWARDED_PORT=POSSIBLY_A_PORT_FOR_THE_X_FORWARDED_PORT_HEADER \
       -v /path/to/secrets/cert.crt:/etc/secrets/proxycert \
       -v /path/to/secrets/key.pem:/etc/secrets/proxykey \
       -v /path/to/secrets/dhparam.pem:/etc/secrets/dhparam \

--- a/nginx/proxy_nossl.conf
+++ b/nginx/proxy_nossl.conf
@@ -5,15 +5,16 @@ upstream target_service {
 server {
   server_name _;
   listen 80;
-  
+
   location / {
     proxy_set_header        Host $host;
     proxy_set_header        X-Real-IP $remote_addr;
     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header        X-Forwarded-Proto $scheme;
+    #proxy_set_header        X-Forwarded-Port {{X-FORWARDED-PORT}};
     proxy_pass http://target_service;
     proxy_read_timeout  90;
     #auth_basic              "Restricted";
-    #auth_basic_user_file    /etc/secrets/htpasswd; 
+    #auth_basic_user_file    /etc/secrets/htpasswd;
   }
 }

--- a/nginx/proxy_ssl.conf
+++ b/nginx/proxy_ssl.conf
@@ -9,7 +9,7 @@ server {
 }
 
 server {
-  server_name _; 
+  server_name _;
   listen 443;
 
   ssl on;
@@ -20,31 +20,31 @@ server {
   ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
   ssl_ciphers ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-RSA-RC4-SHA:AES128-GCM-SHA256:HIGH:!RC4:!MD5:!aNULL:!EDH:!CAMELLIA;
   ssl_prefer_server_ciphers on;
-  
+
   ssl_session_cache shared:SSL:10m;
   ssl_session_timeout 10m;
- 
+
   ssl_session_tickets off;
   ssl_stapling on;
   ssl_stapling_verify on;
   resolver 8.8.8.8 8.8.4.4 valid=300s;
   resolver_timeout 5s;
- 
+
   add_header Strict-Transport-Security max-age=15638400;
   add_header X-Frame-Options DENY;
   add_header X-Content-Type-Options nosniff;
- 
+
   location / {
       proxy_set_header        Host $host;
       proxy_set_header        X-Real-IP $remote_addr;
       proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header        X-Forwarded-Proto $scheme;
       proxy_set_header        X-Forwarded-Host $http_host;
+      #proxy_set_header        X-Forwarded-Port {{X-FORWARDED-PORT}};
       proxy_pass              http://target_service;
       proxy_read_timeout      90;
       proxy_redirect          http:// https://;
       #auth_basic              "Restricted";
-      #auth_basic_user_file    /etc/secrets/htpasswd; 
+      #auth_basic_user_file    /etc/secrets/htpasswd;
   }
 }
-

--- a/start.sh
+++ b/start.sh
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 
-# Env says we're using SSL 
+# Env says we're using SSL
 if [ -n "${ENABLE_SSL+1}" ] && [ "${ENABLE_SSL,,}" = "true" ]; then
   echo "Enabling SSL..."
   cp /usr/src/proxy_ssl.conf /etc/nginx/conf.d/proxy.conf
@@ -21,10 +21,17 @@ else
   cp /usr/src/proxy_nossl.conf /etc/nginx/conf.d/proxy.conf
 fi
 
-# If an htpasswd file is provided, download and configure nginx 
+# If an htpasswd file is provided, download and configure nginx
 if [ -n "${ENABLE_BASIC_AUTH+1}" ] && [ "${ENABLE_BASIC_AUTH,,}" = "true" ]; then
   echo "Enabling basic auth..."
   sed -i "s/#auth_basic/auth_basic/g;" /etc/nginx/conf.d/proxy.conf
+fi
+
+# If X-Forwarded-Port is provided, add it to nginx confinguration
+if [ -n "${X_FORWARDED_PORT+1}" ]; then
+  echo "Adding X-Forwarded-Port..."
+  sed -i "s/#proxy_set_header        X-Forwarded-Port/proxy_set_header        X-Forwarded-Port/g;" /etc/nginx/conf.d/proxy.conf
+  sed -i "s/{{X-FORWARDED-PORT}}/${X_FORWARDED_PORT}/g;" /etc/nginx/conf.d/proxy.conf
 fi
 
 # If the SERVICE_HOST_ENV_NAME and SERVICE_PORT_ENV_NAME vars are provided,


### PR DESCRIPTION
Some applications require the X-FORWARDED-PORT to function correctly.
An exmple is jenkins : https://wiki.jenkins-ci.org/display/JENKINS/Running+Jenkins+behind+Apache
